### PR TITLE
[Feat/38] postId 넘기기 작업 

### DIFF
--- a/src/controller/mainController.ts
+++ b/src/controller/mainController.ts
@@ -30,7 +30,7 @@ export default async(req: Request, res: Response) => {
         });
       }
       else {
-        const getMainService = await mainService(id, "여름", "111");
+        const getMainService = await mainService(id, "여름", "부산");
         res.status(getMainService.status).json(getMainService.data);
       }
     } 

--- a/src/interface/res/briefInformationDTO.ts
+++ b/src/interface/res/briefInformationDTO.ts
@@ -1,4 +1,5 @@
 export default interface briefInformationDTO{
+    postId: number,
     title: string,
     image : string,
     isFavorite: boolean,

--- a/src/service/briefCollectionService.ts
+++ b/src/service/briefCollectionService.ts
@@ -1,0 +1,142 @@
+import { db } from "../models";
+import { QueryTypes } from 'sequelize';
+import briefInformationDTO from "../interface/res/briefInformationDTO";
+
+export async function makeLocalBriefCollection(result:object[], briefCollection: briefInformationDTO[], userId:string){
+    for(let idx in result){
+        const postId = result[idx]['postId'];
+
+        const tempBrief: briefInformationDTO = {
+            title: result[idx]['title'],
+            image: "",
+            isFavorite: false,
+            tags: [],
+        };
+        
+        const promise1 = new Promise( async (resolve, reject) => {
+            const query = `SELECT * 
+                            FROM post_has_image INNER JOIN post_has_tags 
+                            WHERE post_has_image.postId=:postId and
+                            post_has_image.postId = post_has_tags.postId`;
+            const result = await db.sequelize.query(query,{ replacements:{postId:postId},type: QueryTypes.SELECT });
+
+            tempBrief.image = result[0]["image1"];
+            tempBrief.tags.push(result[0]["region"]);
+            tempBrief.tags.push(result[0]["theme"]);
+
+            const warningTag = result[0]["warning"];
+            if(warningTag) tempBrief.tags.push(warningTag);
+
+            resolve("success");
+        });
+
+        const promise2 = new Promise( async (resolve, reject) => {
+
+            const query = "select * from liked_post where PostId = :postId and UserId = :userId";
+            const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT });
+            if(ret.length > 0) tempBrief.isFavorite = true;
+            
+            resolve("success");
+        });
+
+        await Promise.all([promise1, promise2]) 
+            .then(() => { briefCollection.push(tempBrief); })
+            .catch(err => { throw err; })
+    }
+}
+
+export async function makeTrendBriefCollection(result:object[], briefCollection: briefInformationDTO[], userId:string){
+    for(let idx in result){
+        const postId = result[idx]['postId'];
+
+        const tempBrief: briefInformationDTO = {
+            title: result[idx]['title'],
+            image: "",
+            isFavorite: false,
+            tags: [],
+        };
+        
+        const promise1 = new Promise( async (resolve, reject) => {
+            const query = `SELECT * 
+                            FROM post_has_image INNER JOIN post_has_tags 
+                            WHERE post_has_image.postId=:postId and
+                            post_has_image.postId = post_has_tags.postId`;
+            const result = await db.sequelize.query(query,{ replacements:{postId:postId},type: QueryTypes.SELECT });
+
+            tempBrief.image = result[0]["image1"];
+            tempBrief.tags.push(result[0]["region"]);
+            tempBrief.tags.push(result[0]["theme"]);
+
+            const warningTag = result[0]["warning"];
+            if(warningTag) tempBrief.tags.push(warningTag);
+
+            resolve("success");
+        });
+
+        const promise2 = new Promise( async (resolve, reject) => {
+            
+            const query = "select * from liked_post where PostId = :postId and UserId = :userId";
+            const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT });
+            if(ret.length > 0) tempBrief.isFavorite = true;
+            
+            resolve("success");
+        });
+
+        await Promise.all([promise1, promise2]) 
+            .then(() => { briefCollection.push(tempBrief); })
+            .catch(err => { throw err; })
+    }
+}
+
+export async function makeThemeBriefCollection(result:object[], briefCollection: briefInformationDTO[], userId:string){
+    for(let idx in result){
+        const postId = result[idx]['postId'];
+        const tempBrief: briefInformationDTO = {
+            title: "",
+            image: "",
+            isFavorite: false,
+            tags: [],
+        };
+
+        const promise1 = new Promise( async (resolve, reject) => {
+            const result = await db.Post.findOne({
+                include:[
+                    {
+                        model: db.PostHasImage,
+                        attributes:['image1']
+                    },
+                    {
+                        model: db.PostHasTags,
+                        attributes:['region', 'theme', 'warning']
+                    }
+                ],
+                where: { id: postId }, 
+                attributes: ['title'],
+                raw: true,
+                nest : true
+            })
+
+            tempBrief.title = result['title'];
+            tempBrief.title = result['title'];
+            tempBrief.image = result['PostHasImage']['image1'];
+            tempBrief.tags.push(result['PostHasTag']['region']);
+            tempBrief.tags.push(result['PostHasTag']['theme']);
+            
+            const warningTag = result["PostHasTag.warning"];
+            if(warningTag) tempBrief.tags.push(warningTag);
+
+            resolve("success");  
+        });
+        
+        const promise2 = new Promise( async (resolve, reject) => {
+            const query = "select * from liked_post where PostId = :postId and UserId = :userId";
+            const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT });
+            if(ret.length > 0) tempBrief.isFavorite = true;
+            resolve("success");
+        });
+
+        await Promise.all([promise1, promise2]) 
+        .then(() => { briefCollection.push(tempBrief); })
+        .catch(err => { throw err; })
+    }
+}

--- a/src/service/briefCollectionService.ts
+++ b/src/service/briefCollectionService.ts
@@ -7,6 +7,7 @@ export async function makeLocalBriefCollection(result:object[], briefCollection:
         const postId = result[idx]['postId'];
 
         const tempBrief: briefInformationDTO = {
+            postId:postId,
             title: result[idx]['title'],
             image: "",
             isFavorite: false,
@@ -50,6 +51,7 @@ export async function makeTrendBriefCollection(result:object[], briefCollection:
         const postId = result[idx]['postId'];
 
         const tempBrief: briefInformationDTO = {
+            postId:postId,
             title: result[idx]['title'],
             image: "",
             isFavorite: false,
@@ -92,6 +94,7 @@ export async function makeThemeBriefCollection(result:object[], briefCollection:
     for(let idx in result){
         const postId = result[idx]['postId'];
         const tempBrief: briefInformationDTO = {
+            postId:postId,
             title: "",
             image: "",
             isFavorite: false,

--- a/src/service/mainService.ts
+++ b/src/service/mainService.ts
@@ -55,6 +55,7 @@ export default async function mainService(userId: string, theme: string, region:
                 const postId = result[idx]['postId'];
     
                 const tempBrief: briefInformationDTO = {
+                    postId:postId,
                     title: result[idx]['title'],
                     image: "",
                     isFavorite: false,
@@ -103,55 +104,11 @@ export default async function mainService(userId: string, theme: string, region:
                 
             const result = await db.sequelize.query(query,{ type: QueryTypes.SELECT, nest : true});
             await makeTrendBriefCollection(result, trend, userId);
-
-            /*
-            for(let idx in result){
-                const postId = result[idx]['postId'];
-    
-                const tempBrief: briefInformationDTO = {
-                    title: result[idx]['title'],
-                    image: "",
-                    isFavorite: false,
-                    tags: [],
-                };
-                
-                const promise1 = new Promise( async (resolve, reject) => {
-                    const query = `SELECT * 
-                                    FROM post_has_image INNER JOIN post_has_tags 
-                                    WHERE post_has_image.postId=:postId and
-                                    post_has_image.postId = post_has_tags.postId `;
-                    const result = await db.sequelize.query(query,{ replacements:{postId:postId},type: QueryTypes.SELECT, nest:true });
-    
-                    tempBrief.image = result[0]["image1"];
-                    tempBrief.tags.push(result[0]["region"]);
-                    tempBrief.tags.push(result[0]["theme"]);
-    
-                    const warningTag = result[0]["warning"];
-                    if(warningTag) tempBrief.tags.push(warningTag);
-    
-                    resolve("success");
-                });
-    
-                const promise2 = new Promise( async (resolve, reject) => {
-                    
-                    const query = "select * from liked_post where PostId = :postId and UserId = :userId";
-                    const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT, nest:true });
-                    if(ret.length > 0) tempBrief.isFavorite = true;
-                    
-                    resolve("success");
-                });
-    
-                await Promise.all([promise1, promise2]) 
-                    .then(() => { trend.push(tempBrief); })
-                    .catch(err => { throw err; })
-            }
-            */
             resolve("success");
         })
 
         // theme 기준
         const themePromise = new Promise( async (resolve, reject) => {
-
             const customTitle = await db.CustomTheme.findOne({where: {customTheme:theme}, attributes:['customThemeTitle'], raw: true, nest : true} );
             main.customThemeTitle = customTitle['customThemeTitle'];
 
@@ -162,58 +119,7 @@ export default async function mainService(userId: string, theme: string, region:
 
                     const result = await db.sequelize.query(query,{ replacements:{theme:theme},type: QueryTypes.SELECT, nest:true });
                     await makeThemeBriefCollection(result, custom, userId);
-                    /* test 필요
-                    for(let idx in result){
-                        const postId = result[idx]['postId'];
-        
-                        const tempBrief: briefInformationDTO = {
-                            title: "",
-                            image: "",
-                            isFavorite: false,
-                            tags: [],
-                        };
-          
-                        const promise1 = new Promise( async (resolve, reject) => {
-                            const result = await db.Post.findOne({
-                                include:[
-                                    {
-                                        model: db.PostHasImage,
-                                        attributes:['image1']
-                                    },
-                                    {
-                                        model: db.PostHasTags,
-                                        attributes:['region', 'theme', 'warning']
-                                    }
-                                ],
-                                where: { id: postId }, 
-                                attributes: ['title'],
-                                raw: true,
-                                nest: true
-                            })
-        
-                            tempBrief.title = result['title'];
-                            tempBrief.image = result['PostHasImage']['image1'];
-                            tempBrief.tags.push(result['PostHasTag']['region']);
-                            tempBrief.tags.push(result['PostHasTag']['theme']);
-                            
-                            const warningTag = result["PostHasTag.warning"];
-                            if(warningTag) tempBrief.tags.push(warningTag);
-        
-                            resolve("success");  
-                        });
-                        
-                        const promise2 = new Promise( async (resolve, reject) => {
-                            const query = "select * from liked_post where PostId = :postId and UserId = :userId";
-                            const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT, nest: true });
-                            if(ret.length > 0) tempBrief.isFavorite = true;
-                            resolve("success");
-                        });
-        
-                        await Promise.all([promise1, promise2]) 
-                        .then(() => { custom.push(tempBrief); })
-                        .catch(err => { throw err; })
-                }
-                */
+
             resolve("success");
         });
 
@@ -230,48 +136,6 @@ export default async function mainService(userId: string, theme: string, region:
             
             const result = await db.sequelize.query(query,{ replacements:{region:region},type: QueryTypes.SELECT });
             await makeLocalBriefCollection(result, local, userId);
-            /*
-            for(let idx in result){
-                const postId = result[idx]['postId'];
-    
-                const tempBrief: briefInformationDTO = {
-                    title: result[idx]['title'],
-                    image: "",
-                    isFavorite: false,
-                    tags: [],
-                };
-                
-                const promise1 = new Promise( async (resolve, reject) => {
-                    const query = `SELECT * 
-                                    FROM post_has_image INNER JOIN post_has_tags 
-                                    WHERE post_has_image.postId=:postId and
-                                    post_has_image.postId = post_has_tags.postId`;
-                    const result = await db.sequelize.query(query,{ replacements:{postId:postId},type: QueryTypes.SELECT });
-    
-                    tempBrief.image = result[0]["image1"];
-                    tempBrief.tags.push(result[0]["region"]);
-                    tempBrief.tags.push(result[0]["theme"]);
-    
-                    const warningTag = result[0]["warning"];
-                    if(warningTag) tempBrief.tags.push(warningTag);
-    
-                    resolve("success");
-                });
-    
-                const promise2 = new Promise( async (resolve, reject) => {
-
-                    const query = "select * from liked_post where PostId = :postId and UserId = :userId";
-                    const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT });
-                    if(ret.length > 0) tempBrief.isFavorite = true;
-                    
-                    resolve("success");
-                });
-    
-                await Promise.all([promise1, promise2]) 
-                    .then(() => { local.push(tempBrief); })
-                    .catch(err => { throw err; })
-            }
-            */
     
             resolve("success");
         });
@@ -279,10 +143,10 @@ export default async function mainService(userId: string, theme: string, region:
         await Promise.all([bannerPromise, todayPromise, trendPromise, themePromise, localPromise]) 
                 .catch(err => { throw err; })
 
-        
         return {
             status: 200,
             data:{
+                success: true,
                 msg : "successfully load main view data",
                 data : main
             }
@@ -293,6 +157,7 @@ export default async function mainService(userId: string, theme: string, region:
         return {
             status: 502,
             data:{
+                success: false,
                 msg : "DB main view loading error"
             }
         }

--- a/src/service/mainService.ts
+++ b/src/service/mainService.ts
@@ -5,6 +5,8 @@ import mainDTO from '../interface/res/mainDTO';
 import bannerDTO from "../interface/res/bannerDTO";
 import briefInformationDTO from "../interface/res/briefInformationDTO";
 
+import { makeThemeBriefCollection, makeTrendBriefCollection, makeLocalBriefCollection } from "./briefCollectionService";
+
 export default async function mainService(userId: string, theme: string, region: string){
     try{
 
@@ -100,7 +102,9 @@ export default async function mainService(userId: string, theme: string, region:
                     GROUP BY P.id ORDER BY favoriteCount DESC LIMIT 4`;
                 
             const result = await db.sequelize.query(query,{ type: QueryTypes.SELECT, nest : true});
+            await makeTrendBriefCollection(result, trend, userId);
 
+            /*
             for(let idx in result){
                 const postId = result[idx]['postId'];
     
@@ -141,6 +145,7 @@ export default async function mainService(userId: string, theme: string, region:
                     .then(() => { trend.push(tempBrief); })
                     .catch(err => { throw err; })
             }
+            */
             resolve("success");
         })
 
@@ -156,7 +161,8 @@ export default async function mainService(userId: string, theme: string, region:
                     GROUP BY P.postId ORDER BY favoriteCount DESC LIMIT 4`;
 
                     const result = await db.sequelize.query(query,{ replacements:{theme:theme},type: QueryTypes.SELECT, nest:true });
-
+                    await makeThemeBriefCollection(result, custom, userId);
+                    /* test 필요
                     for(let idx in result){
                         const postId = result[idx]['postId'];
         
@@ -207,13 +213,14 @@ export default async function mainService(userId: string, theme: string, region:
                         .then(() => { custom.push(tempBrief); })
                         .catch(err => { throw err; })
                 }
+                */
             resolve("success");
         });
 
         // local city
         const localPromise = new Promise( async (resolve, reject) => {
             
-            const localTitle = await db.Local.findOne({where: {localCity:region}, raw:true, attributes:['localTitle']} );
+            const localTitle = await db.Local.findOne({where: {localCity:region}, raw:true, attributes:['localTitle'], nest: true} );
             main.localTitle = localTitle['localTitle'];
 
             const query = `select count(liked_post.PostId) as favoriteCount, P.id as postId, P.title
@@ -222,7 +229,8 @@ export default async function mainService(userId: string, theme: string, region:
                     GROUP BY P.id ORDER BY favoriteCount DESC LIMIT 4`;
             
             const result = await db.sequelize.query(query,{ replacements:{region:region},type: QueryTypes.SELECT });
-
+            await makeLocalBriefCollection(result, local, userId);
+            /*
             for(let idx in result){
                 const postId = result[idx]['postId'];
     
@@ -263,6 +271,7 @@ export default async function mainService(userId: string, theme: string, region:
                     .then(() => { local.push(tempBrief); })
                     .catch(err => { throw err; })
             }
+            */
     
             resolve("success");
         });

--- a/src/service/previewLocalService.ts
+++ b/src/service/previewLocalService.ts
@@ -6,6 +6,8 @@ import previewDTO from "../interface/res/previewDTO";
 
 import previewMap from "./previewMap.json";
 
+import { makeLocalBriefCollection } from "./briefCollectionService";
+
 export default async function previewThemeService(local: string, userId: string){
 
     const regionName = previewMap.region[local];
@@ -15,7 +17,7 @@ export default async function previewThemeService(local: string, userId: string)
                     LEFT OUTER JOIN liked_post ON(P.id = liked_post.PostId)
                     GROUP BY P.id ORDER BY favoriteCount DESC LIMIT 20`;
     
-    const result = await db.sequelize.query(query,{ replacements:{region:local},type: QueryTypes.SELECT });
+    const result = await db.sequelize.query(query,{ replacements:{region:regionName},type: QueryTypes.SELECT });
 
     let brief: briefInformationDTO[] = []
 
@@ -25,6 +27,8 @@ export default async function previewThemeService(local: string, userId: string)
     };
 
     try{
+        await makeLocalBriefCollection(result, brief, userId);
+        /* 테스트
         for(let idx in result){
             const postId = result[idx]['postId'];
 
@@ -53,7 +57,6 @@ export default async function previewThemeService(local: string, userId: string)
             });
 
             const promise2 = new Promise( async (resolve, reject) => {
-                console.log("posIIDI", postId);
                 
                 const query = "select * from liked_post where PostId = :postId and UserId = :userId";
                 const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT });
@@ -66,7 +69,7 @@ export default async function previewThemeService(local: string, userId: string)
                 .then(() => { brief.push(tempBrief); })
                 .catch(err => { throw err; })
         }
-
+        */
         return {
             status: 200,
             data:{

--- a/src/service/previewThemeService.ts
+++ b/src/service/previewThemeService.ts
@@ -5,6 +5,8 @@ import previewDTO from "../interface/res/previewDTO";
 
 import previewMap from "./previewMap.json";
 
+import { makeThemeBriefCollection } from "./briefCollectionService";
+
 export default async function previewThemeService(theme: string, userId: string){
 
     const themeName = previewMap.theme[theme];
@@ -22,6 +24,9 @@ export default async function previewThemeService(theme: string, userId: string)
         drive: brief
     };
     try{
+        await makeThemeBriefCollection(result, brief, userId);
+        //console.log()
+        /*
         for(let idx in result){
                 const postId = result[idx]['postId'];
 
@@ -46,13 +51,15 @@ export default async function previewThemeService(theme: string, userId: string)
                         ],
                         where: { id: postId }, 
                         attributes: ['title'],
-                        raw: true
+                        raw: true,
+                        nest : true
                     })
 
                     tempBrief.title = result['title'];
-                    tempBrief.image = result['PostHasImage.image1'];
-                    tempBrief.tags.push(result['PostHasTag.region']);
-                    tempBrief.tags.push(result["PostHasTag.theme"]);
+                    tempBrief.title = result['title'];
+                    tempBrief.image = result['PostHasImage']['image1'];
+                    tempBrief.tags.push(result['PostHasTag']['region']);
+                    tempBrief.tags.push(result['PostHasTag']['theme']);
                     
                     const warningTag = result["PostHasTag.warning"];
                     if(warningTag) tempBrief.tags.push(warningTag);
@@ -71,7 +78,8 @@ export default async function previewThemeService(theme: string, userId: string)
                 .then(() => { brief.push(tempBrief); })
                 .catch(err => { throw err; })
         }
-        
+        */
+
         return {
             status: 200,
             data:{

--- a/src/service/previewTodayService.ts
+++ b/src/service/previewTodayService.ts
@@ -5,6 +5,8 @@ import previewDTO from "../interface/res/previewDTO";
 
 import previewMap from "./previewMap.json";
 
+import { makeTrendBriefCollection } from "./briefCollectionService";
+
 export default async function previewTodayService(userId: string){
     //count(PostId) as favoriteCount, PostId   ~ ORDER BY favoriteCount DESC`
     const query = `select P.id as postId, count(liked_post.PostId) as favoriteCount
@@ -22,6 +24,9 @@ export default async function previewTodayService(userId: string){
     };
     
     try{
+        await makeTrendBriefCollection(result, brief, userId);
+        console.log(brief);
+        /* test 필요
         for(let idx in result){
             const postId = result[idx]['postId'];
 
@@ -50,7 +55,6 @@ export default async function previewTodayService(userId: string){
             });
 
             const promise2 = new Promise( async (resolve, reject) => {
-                console.log("posIIDI", postId);
                 
                 const query = "select * from liked_post where PostId = :postId and UserId = :userId";
                 const ret = await db.sequelize.query(query,{ replacements:{postId:postId, userId:userId},type: QueryTypes.SELECT });
@@ -63,6 +67,7 @@ export default async function previewTodayService(userId: string){
                 .then(() => { brief.push(tempBrief); })
                 .catch(err => { throw err; })
         }
+        */
 
         return {
             status: 200,


### PR DESCRIPTION
## 🌈 PR 요약
* 게시물 상세 조회에 필요한 postId 게시물 마다 넘겨주기
* 프리뷰 - 메인뷰에 겹치는 함수 빼기

## 📌 변경 사항
* brief DTO 변경 (postId 영역 추가)
* service/breifCollection.ts 에 겹치는 함수들 빼놓고 메인뷰, 더보기뷰 각각 export하여 사용

## 📸 ScreenShot
![image](https://user-images.githubusercontent.com/63635886/125174035-77558180-e1fd-11eb-92b1-19100110941f.png)

#### Linked Issue
closes #38 
