### PR TITLE
[feat] 마케팅푸시, 마케팅이메일 동의 컬럼 추가(pushAlarm은 컬럼명 변경)

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -11,7 +11,8 @@ interface UserAttributes {
     email: string;
     nickname: string;
     profileImage: string;
-    pushAlarm: number;
+    marketingPush: boolean;
+    marketingEmail: boolean;
 };
 
 export default class User extends Model<UserAttributes> {
@@ -21,7 +22,8 @@ export default class User extends Model<UserAttributes> {
     public email!: string;
     public nickname!: string;
     public profileImage!: string;
-    public pushAlarm!: boolean;
+    public marketingPush!: boolean;
+    public marketingEmail!: boolean;
 
     public static associations: {
     };
@@ -51,7 +53,12 @@ User.init(
             type: DataTypes.STRING(100),
             defaultValue: "*"
         },
-        pushAlarm: {
+        marketingPush: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        },
+        marketingEmail: {
             type: DataTypes.BOOLEAN,
             allowNull: false,
             defaultValue: false


### PR DESCRIPTION

## 🌈 PR 요약
마케팅푸시, 마케팅이메일 동의 컬럼 추가(pushAlarm은 컬럼명 변경)

## 📌 변경 사항

1. marketingPush (유저의 마케팅 푸시알림 수신 동의 여부를 저장할 컬럼) 

- 컬럼명 변경 (pushAlarm => marketingPush)

2. marketingEmail (유저의 마케팅 이메일 수신 동의 여부를 저장할 컬럼) 추가


## 📸 ScreenShot
<img width="258" alt="스크린샷 2021-07-11 오후 10 27 27" src="https://user-images.githubusercontent.com/63224278/125197056-327e2900-e297-11eb-90d7-1c393e6b6f73.png">
<img width="388" alt="스크린샷 2021-07-11 오후 10 27 33" src="https://user-images.githubusercontent.com/63224278/125197059-3447ec80-e297-11eb-89d2-d00448f6805f.png">


#### Linked Issue
Closing '#45'
